### PR TITLE
公式渲染优化

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ theme:
     edit: material/pencil
   features:
     - search.highlight
-    - navigation.instant
+#    - navigation.instant
     - navigation.tracking
     - navigation.tabs
     - navigation.prune


### PR DESCRIPTION
1. 修改内容：禁用navigation.instant；
2. 修改原因：instant启用后会导致刚进入网页时公式渲染失败，需要手动刷新一次才能展示正确的公式渲染；
3. 请谨慎对待这个PR，因为笔者并未研究instant与公式渲染是否具有直接关系（但是instant其实也不是很必要）；